### PR TITLE
UI Cleanup and improvements

### DIFF
--- a/android/src/main/java/app/shosetsu/android/common/SettingKey.kt
+++ b/android/src/main/java/app/shosetsu/android/common/SettingKey.kt
@@ -201,6 +201,7 @@ sealed class SettingKey<T : Any>(val name: String, val default: T) {
 	// View options
 	object ChapterColumnsInPortait : IntKey("columnsInNovelsViewP", 3)
 	object ChapterColumnsInLandscape : IntKey("columnsInNovelsViewH", 6)
+	object NovelBadgeToast : BooleanKey("novelBadge", true)
 	object SelectedNovelCardType : IntKey("novelCardType", 0)
 	object NavStyle : IntKey("navigationStyle", 0)
 

--- a/android/src/main/java/app/shosetsu/android/common/utils/uifactory/BrowseExtensionConversionFactory.kt
+++ b/android/src/main/java/app/shosetsu/android/common/utils/uifactory/BrowseExtensionConversionFactory.kt
@@ -1,0 +1,52 @@
+package app.shosetsu.android.common.utils.uifactory
+
+import app.shosetsu.android.domain.model.local.BrowseExtensionEntity
+import app.shosetsu.android.view.uimodels.model.BrowseExtensionUI
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapLatest
+
+/*
+ * This file is part of Shosetsu.
+ *
+ * Shosetsu is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Shosetsu is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Shosetsu.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * shosetsu
+ * 05 / 12 / 2020
+ */
+class BrowseExtensionConversionFactory(data: BrowseExtensionEntity) :
+	UIConversionFactory<BrowseExtensionEntity, BrowseExtensionUI>(data) {
+	override fun BrowseExtensionEntity.convertTo(): BrowseExtensionUI = BrowseExtensionUI(
+		id = id,
+		name = name,
+		imageURL = imageURL,
+		lang = lang,
+		installOptions = installOptions,
+		isInstalled = isInstalled,
+		installedVersion = installedVersion,
+		installedRepo = installedRepo,
+		isUpdateAvailable = isUpdateAvailable,
+		updateVersion = updateVersion,
+		isInstalling = isInstalling,
+	)
+}
+
+fun List<BrowseExtensionEntity>.mapToFactory() =
+	map { BrowseExtensionConversionFactory(it) }
+
+@OptIn(ExperimentalCoroutinesApi::class)
+fun Flow<List<BrowseExtensionEntity>>.mapLatestToResultFlowWithFactory() =
+	mapLatest { it.mapToFactory() }

--- a/android/src/main/java/app/shosetsu/android/common/utils/uifactory/InstalledExtensionConversionFactory.kt
+++ b/android/src/main/java/app/shosetsu/android/common/utils/uifactory/InstalledExtensionConversionFactory.kt
@@ -1,0 +1,52 @@
+package app.shosetsu.android.common.utils.uifactory
+
+import app.shosetsu.android.domain.model.local.InstalledExtensionEntity
+import app.shosetsu.android.view.uimodels.model.InstalledExtensionUI
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapLatest
+
+/*
+ * This file is part of Shosetsu.
+ *
+ * Shosetsu is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Shosetsu is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Shosetsu.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * shosetsu
+ * 05 / 12 / 2020
+ */
+class InstalledExtensionConversionFactory(data: InstalledExtensionEntity) :
+	UIConversionFactory<InstalledExtensionEntity, InstalledExtensionUI>(data) {
+	override fun InstalledExtensionEntity.convertTo(): InstalledExtensionUI = InstalledExtensionUI(
+		id = id,
+		repoID = repoID,
+		name = name,
+		fileName = fileName,
+		imageURL = imageURL,
+		lang = lang,
+		version = version,
+		md5 = md5,
+		type = type,
+		enabled = enabled,
+		chapterType = chapterType,
+	)
+}
+
+fun List<InstalledExtensionEntity>.mapToFactory() =
+	map { InstalledExtensionConversionFactory(it) }
+
+@OptIn(ExperimentalCoroutinesApi::class)
+fun Flow<List<InstalledExtensionEntity>>.mapLatestToResultFlowWithFactory() =
+	mapLatest { it.mapToFactory() }

--- a/android/src/main/java/app/shosetsu/android/di/UseCaseModule.kt
+++ b/android/src/main/java/app/shosetsu/android/di/UseCaseModule.kt
@@ -174,6 +174,7 @@ val useCaseModule: DI.Module = DI.Module("useCase") {
 
 	bind<LoadNovelUIColumnsPUseCase>() with provider { LoadNovelUIColumnsPUseCase(instance()) }
 	bind<LoadNovelUIColumnsHUseCase>() with provider { LoadNovelUIColumnsHUseCase(instance()) }
+	bind<LoadNovelUIBadgeToastUseCase>() with provider { LoadNovelUIBadgeToastUseCase(instance()) }
 	bind<LoadNovelUITypeUseCase>() with provider { LoadNovelUITypeUseCase(instance()) }
 	bind<StartAppUpdateInstallWorkerUseCase>() with provider {
 		StartAppUpdateInstallWorkerUseCase(instance())

--- a/android/src/main/java/app/shosetsu/android/di/ViewModelsModule.kt
+++ b/android/src/main/java/app/shosetsu/android/di/ViewModelsModule.kt
@@ -60,7 +60,8 @@ val viewModelsModule: DI.Module = DI.Module("view_models_module") {
 			loadNovelUITypeUseCase = instance(),
 			setNovelUITypeUseCase = instance(),
 			loadNovelUIColumnsH = instance(),
-			loadNovelUIColumnsP = instance()
+			loadNovelUIColumnsP = instance(),
+			loadNovelUIBadgeToast = instance()
 		)
 	}
 

--- a/android/src/main/java/app/shosetsu/android/domain/usecases/CancelExtensionInstallUseCase.kt
+++ b/android/src/main/java/app/shosetsu/android/domain/usecases/CancelExtensionInstallUseCase.kt
@@ -1,7 +1,7 @@
 package app.shosetsu.android.domain.usecases
 
-import app.shosetsu.android.domain.model.local.BrowseExtensionEntity
 import app.shosetsu.android.domain.repository.base.IExtensionDownloadRepository
+import app.shosetsu.android.view.uimodels.model.BrowseExtensionUI
 
 /*
  * This file is part of shosetsu.
@@ -30,7 +30,7 @@ class CancelExtensionInstallUseCase(
 	private val repo: IExtensionDownloadRepository
 ) {
 
-	suspend operator fun invoke(extension: BrowseExtensionEntity) {
+	suspend operator fun invoke(extension: BrowseExtensionUI) {
 		repo.remove(extension.id)
 	}
 }

--- a/android/src/main/java/app/shosetsu/android/domain/usecases/RequestInstallExtensionUseCase.kt
+++ b/android/src/main/java/app/shosetsu/android/domain/usecases/RequestInstallExtensionUseCase.kt
@@ -5,10 +5,10 @@ import app.shosetsu.android.backend.workers.onetime.ExtensionInstallWorker
 import app.shosetsu.android.backend.workers.onetime.ExtensionInstallWorker.Companion.KEY_EXTENSION_ID
 import app.shosetsu.android.backend.workers.onetime.ExtensionInstallWorker.Companion.KEY_REPOSITORY_ID
 import app.shosetsu.android.common.enums.DownloadStatus
-import app.shosetsu.android.domain.model.local.BrowseExtensionEntity
 import app.shosetsu.android.domain.model.local.ExtensionInstallOptionEntity
 import app.shosetsu.android.domain.repository.base.IExtensionDownloadRepository
 import app.shosetsu.android.domain.repository.base.IExtensionsRepository
+import app.shosetsu.android.view.uimodels.model.BrowseExtensionUI
 
 /*
  * This file is part of shosetsu.
@@ -37,7 +37,7 @@ class RequestInstallExtensionUseCase(
 	private val manager: ExtensionInstallWorker.Manager
 ) {
 	suspend operator fun invoke(
-		extension: BrowseExtensionEntity,
+		extension: BrowseExtensionUI,
 		option: ExtensionInstallOptionEntity
 	) =
 		invoke(extension.id, option.repoId)
@@ -46,7 +46,7 @@ class RequestInstallExtensionUseCase(
 	 * Update an extension
 	 */
 	suspend operator fun invoke(
-		extension: BrowseExtensionEntity,
+		extension: BrowseExtensionUI,
 	) =
 		invoke(extension.id, extension.installedRepo)
 

--- a/android/src/main/java/app/shosetsu/android/domain/usecases/UninstallExtensionUseCase.kt
+++ b/android/src/main/java/app/shosetsu/android/domain/usecases/UninstallExtensionUseCase.kt
@@ -2,9 +2,9 @@ package app.shosetsu.android.domain.usecases
 
 import android.database.sqlite.SQLiteException
 import app.shosetsu.android.common.ext.generify
-import app.shosetsu.android.domain.model.local.InstalledExtensionEntity
 import app.shosetsu.android.domain.repository.base.IExtensionEntitiesRepository
 import app.shosetsu.android.domain.repository.base.IExtensionsRepository
+import app.shosetsu.android.view.uimodels.model.InstalledExtensionUI
 
 /*
  * This file is part of shosetsu.
@@ -32,7 +32,8 @@ class UninstallExtensionUseCase(
 	private val extensionEntitiesRepository: IExtensionEntitiesRepository
 ) {
 	@Throws(SQLiteException::class)
-	suspend operator fun invoke(extensionEntity: InstalledExtensionEntity) {
+	suspend operator fun invoke(extensionUI: InstalledExtensionUI) {
+		val extensionEntity = extensionUI.convertTo()
 		extensionEntitiesRepository.uninstall(extensionEntity.generify())
 		extensionRepository.uninstall(extensionEntity)
 	}

--- a/android/src/main/java/app/shosetsu/android/domain/usecases/get/GetInstalledExtensionUseCase.kt
+++ b/android/src/main/java/app/shosetsu/android/domain/usecases/get/GetInstalledExtensionUseCase.kt
@@ -1,8 +1,10 @@
 package app.shosetsu.android.domain.usecases.get
 
-import app.shosetsu.android.domain.model.local.InstalledExtensionEntity
+import app.shosetsu.android.common.utils.uifactory.InstalledExtensionConversionFactory
 import app.shosetsu.android.domain.repository.base.IExtensionsRepository
+import app.shosetsu.android.view.uimodels.model.InstalledExtensionUI
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapLatest
 
 /*
  * This file is part of shosetsu.
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.Flow
 class GetInstalledExtensionUseCase(
 	private val iExtensionsRepository: IExtensionsRepository,
 ) {
-	operator fun invoke(id: Int): Flow<InstalledExtensionEntity?> =
+	operator fun invoke(id: Int): Flow<InstalledExtensionUI?> =
 		iExtensionsRepository.getInstalledExtensionFlow(id)
+			.mapLatest { it?.let { InstalledExtensionConversionFactory(it).convertTo() } }
 }

--- a/android/src/main/java/app/shosetsu/android/domain/usecases/load/LoadBrowseExtensionsUseCase.kt
+++ b/android/src/main/java/app/shosetsu/android/domain/usecases/load/LoadBrowseExtensionsUseCase.kt
@@ -1,11 +1,19 @@
 package app.shosetsu.android.domain.usecases.load
 
 import app.shosetsu.android.common.enums.DownloadStatus
+import app.shosetsu.android.common.utils.uifactory.mapLatestToResultFlowWithFactory
 import app.shosetsu.android.domain.model.local.BrowseExtensionEntity
 import app.shosetsu.android.domain.repository.base.IExtensionDownloadRepository
 import app.shosetsu.android.domain.repository.base.IExtensionsRepository
+import app.shosetsu.android.dto.convertList
+import app.shosetsu.android.view.uimodels.model.BrowseExtensionUI
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.flow.transformLatest
 
 /*
  * This file is part of shosetsu.
@@ -33,7 +41,7 @@ class LoadBrowseExtensionsUseCase(
 	private val extensionDownloadRepository: IExtensionDownloadRepository
 ) {
 	@OptIn(ExperimentalCoroutinesApi::class)
-	operator fun invoke(): Flow<List<BrowseExtensionEntity>> =
+	operator fun invoke(): Flow<List<BrowseExtensionUI>> =
 		extensionsRepository.loadBrowseExtensions()
 			.transformLatest { extensionList -> // Merge with downloadStatus
 				val listOfFlows: List<Flow<BrowseExtensionEntity?>> =
@@ -56,5 +64,7 @@ class LoadBrowseExtensionsUseCase(
 				// Emit as a success
 				emitAll(b)
 			}
+			.mapLatestToResultFlowWithFactory()
+			.mapLatest { it.convertList() }
 
 }

--- a/android/src/main/java/app/shosetsu/android/domain/usecases/load/LoadNovelUIBadgeToastUseCase.kt
+++ b/android/src/main/java/app/shosetsu/android/domain/usecases/load/LoadNovelUIBadgeToastUseCase.kt
@@ -1,0 +1,31 @@
+package app.shosetsu.android.domain.usecases.load
+
+import app.shosetsu.android.common.SettingKey
+import app.shosetsu.android.domain.repository.base.ISettingsRepository
+
+/*
+ * This file is part of Shosetsu.
+ *
+ * Shosetsu is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Shosetsu is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Shosetsu.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * shosetsu
+ * 08 / 12 / 2020
+ */
+class LoadNovelUIBadgeToastUseCase(
+	private val iSettingsRepository: ISettingsRepository
+) {
+	operator fun invoke() = iSettingsRepository.getBooleanFlow(SettingKey.NovelBadgeToast)
+}

--- a/android/src/main/java/app/shosetsu/android/ui/add/AddShareController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/add/AddShareController.kt
@@ -27,7 +27,9 @@ import app.shosetsu.android.common.consts.BundleKeys
 import app.shosetsu.android.common.ext.*
 import app.shosetsu.android.view.compose.ErrorAction
 import app.shosetsu.android.view.compose.ErrorContent
+import app.shosetsu.android.view.compose.ImageLoadingError
 import app.shosetsu.android.view.compose.ShosetsuCompose
+import app.shosetsu.android.view.compose.coverRatio
 import app.shosetsu.android.view.controller.ShosetsuController
 import app.shosetsu.android.view.controller.base.CollapsedToolBarController
 import app.shosetsu.android.viewmodel.abstracted.AAddShareViewModel
@@ -36,8 +38,11 @@ import app.shosetsu.lib.share.NovelLink
 import app.shosetsu.lib.share.RepositoryLink
 import app.shosetsu.lib.share.StyleLink
 import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import com.github.doomsdayrs.apps.shosetsu.R
+import com.google.accompanist.placeholder.material.placeholder
+import com.google.accompanist.placeholder.placeholder
 import io.github.g00fy2.quickie.QRResult
 import io.github.g00fy2.quickie.ScanQRCode
 import io.github.g00fy2.quickie.content.QRContent
@@ -360,16 +365,21 @@ fun AddShareContent(
 										verticalAlignment = Alignment.CenterVertically
 									) {
 
-										AsyncImage(
+										SubcomposeAsyncImage(
 											model = ImageRequest.Builder(LocalContext.current)
 												.data(novelLink.imageURL)
-												.error(R.drawable.broken_image)
-												.placeholder(R.drawable.animated_refresh)
+												.crossfade(true)
 												.build(),
 											contentDescription = null,
 											modifier = Modifier
 												.heightIn(max = 128.dp)
-												.aspectRatio(.75f)
+												.aspectRatio(coverRatio),
+											error = {
+												ImageLoadingError()
+											},
+											loading = {
+												Box(Modifier.placeholder(true))
+											}
 										)
 										Column(
 											modifier = Modifier.padding(start = 8.dp)
@@ -412,14 +422,19 @@ fun AddShareContent(
 									Row(
 										verticalAlignment = Alignment.CenterVertically
 									) {
-										AsyncImage(
+										SubcomposeAsyncImage(
 											ImageRequest.Builder(LocalContext.current)
 												.data(extensionLink.imageURL)
-												.placeholder(R.drawable.animated_refresh)
-												.error(R.drawable.broken_image)
+												.crossfade(true)
 												.build(),
 											"",
-											modifier = Modifier.size(64.dp)
+											modifier = Modifier.size(64.dp),
+											error = {
+												ImageLoadingError()
+											},
+											loading = {
+												Box(Modifier.placeholder(true))
+											}
 										)
 										Text(
 											extensionLink.name,

--- a/android/src/main/java/app/shosetsu/android/ui/browse/BrowseControllerFilterMenu.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/browse/BrowseControllerFilterMenu.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -72,7 +73,7 @@ fun BrowseControllerFilterMenu(viewModel: ABrowseViewModel) {
 
 	Column(
 		modifier = Modifier
-			.fillMaxWidth()
+			.fillMaxSize()
 			.padding(vertical = 16.dp)
 			.verticalScroll(rememberScrollState())
 	) {

--- a/android/src/main/java/app/shosetsu/android/ui/browse/BrowseControllerFilterMenu.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/browse/BrowseControllerFilterMenu.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -72,6 +74,7 @@ fun BrowseControllerFilterMenu(viewModel: ABrowseViewModel) {
 		modifier = Modifier
 			.fillMaxWidth()
 			.padding(vertical = 16.dp)
+			.verticalScroll(rememberScrollState())
 	) {
 		BrowseControllerNameFilter(searchTerm, viewModel::setSearch)
 
@@ -195,7 +198,8 @@ fun BrowseControllerLanguagesContent(
 	onLanguageChecked: (String, Boolean) -> Unit
 ) {
 	Column(
-		Modifier.fillMaxWidth()
+		Modifier
+			.fillMaxWidth()
 			.padding(top = 8.dp, bottom = 8.dp)
 	) {
 		languages.forEach { language ->

--- a/android/src/main/java/app/shosetsu/android/ui/browse/BrowseControllerFilterMenu.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/browse/BrowseControllerFilterMenu.kt
@@ -1,10 +1,25 @@
 package app.shosetsu.android.ui.browse
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Checkbox
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconToggleButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -14,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import app.shosetsu.android.view.compose.ShosetsuCompose
 import app.shosetsu.android.viewmodel.abstracted.ABrowseViewModel
 import app.shosetsu.android.viewmodel.abstracted.ABrowseViewModel.FilteredLanguages
+import app.shosetsu.android.viewmodel.abstracted.ABrowseViewModel.LanguageFilter
 import com.github.doomsdayrs.apps.shosetsu.R
 
 /*
@@ -52,9 +68,11 @@ fun BrowseControllerFilterMenu(viewModel: ABrowseViewModel) {
 
 	val searchTerm by viewModel.searchTermLive.collectAsState("")
 
-	Column(modifier = Modifier
-		.fillMaxWidth()
-		.padding(16.dp)) {
+	Column(
+		modifier = Modifier
+			.fillMaxWidth()
+			.padding(vertical = 16.dp)
+	) {
 		BrowseControllerNameFilter(searchTerm, viewModel::setSearch)
 
 		BrowseControllerLanguagesFilter(languageList, hideLanguageFilter,
@@ -66,7 +84,7 @@ fun BrowseControllerFilterMenu(viewModel: ABrowseViewModel) {
 			}
 		)
 
-		Divider(modifier = Modifier.padding(bottom = 8.dp))
+		Divider(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp))
 
 		BrowseControllerInstalledFilter(
 			state = showOnlyInstalled,
@@ -82,12 +100,12 @@ fun PreviewBrowseControllerNameFilter() {
 
 @Composable
 fun BrowseControllerNameFilter(searchTerm: String, setSearchTerm: (newTerm: String) -> Unit) {
-	TextField(
+	OutlinedTextField(
 		value = searchTerm,
 		onValueChange = setSearchTerm,
 		modifier = Modifier
-			.padding(bottom = 8.dp)
-			.fillMaxWidth(),
+			.fillMaxWidth()
+			.padding(horizontal = 16.dp),
 		label = {
 			Text(stringResource(R.string.controller_browse_filter_name_label))
 		}
@@ -98,7 +116,7 @@ fun BrowseControllerNameFilter(searchTerm: String, setSearchTerm: (newTerm: Stri
 @Composable
 fun PreviewBrowseControllerLanguagesFilter() {
 	BrowseControllerLanguagesFilter(
-		FilteredLanguages(listOf("en"), mapOf("en" to true)),
+		FilteredLanguages(listOf(LanguageFilter("en")), mapOf("en" to true)),
 		false,
 		{ _, _ -> },
 		{}
@@ -112,17 +130,22 @@ fun BrowseControllerLanguagesFilter(
 	setLanguageFilterState: (language: String, newState: Boolean) -> Unit,
 	setHidden: (newValue: Boolean) -> Unit
 ) {
-	Column(modifier = Modifier
-		.fillMaxWidth()
-		.padding(bottom = 8.dp)) {
+	Column(
+		modifier = Modifier
+			.fillMaxWidth()
+			.padding(vertical = 8.dp)
+	) {
 		Row(
-			modifier = Modifier.fillMaxWidth(),
+			modifier = Modifier
+				.fillMaxWidth()
+				.height(56.dp)
+				.clickable(onClick = { setHidden(!hidden) }),
 			horizontalArrangement = Arrangement.SpaceBetween,
 			verticalAlignment = Alignment.CenterVertically
 		) {
 			Text(
 				text = stringResource(R.string.languages),
-				Modifier.padding(bottom = 8.dp)
+				Modifier.padding(start = 16.dp, bottom = 8.dp)
 			)
 
 			IconToggleButton(
@@ -138,9 +161,9 @@ fun BrowseControllerLanguagesFilter(
 			}
 		}
 
-		if (!hidden) {
+		AnimatedVisibility(!hidden) {
 			languageList.let { (languages, state) ->
-				Divider(modifier = Modifier.padding(bottom = 8.dp, end = 8.dp))
+				Divider(modifier = Modifier.padding(bottom = 8.dp, end = 8.dp, start = 8.dp))
 
 				BrowseControllerLanguagesContent(
 					languages = languages,
@@ -159,7 +182,7 @@ fun BrowseControllerLanguagesFilter(
 fun PreviewBrowseControllerLanguages() {
 	ShosetsuCompose {
 		BrowseControllerLanguagesContent(
-			languages = listOf("en", "ch", "ru", "fr"),
+			languages = listOf("en", "ch", "ru", "fr").map(::LanguageFilter),
 			state = mapOf("en" to false, "ch" to false, "ru" to true, "fr" to false),
 			onLanguageChecked = { a, b -> })
 	}
@@ -167,16 +190,16 @@ fun PreviewBrowseControllerLanguages() {
 
 @Composable
 fun BrowseControllerLanguagesContent(
-	languages: List<String>,
+	languages: List<LanguageFilter>,
 	state: Map<String, Boolean>,
 	onLanguageChecked: (String, Boolean) -> Unit
 ) {
-	LazyColumn(
-		modifier = Modifier.fillMaxWidth(),
-		contentPadding = PaddingValues(start = 8.dp, top = 8.dp, end = 12.dp)
+	Column(
+		Modifier.fillMaxWidth()
+			.padding(top = 8.dp, bottom = 8.dp)
 	) {
-		items(languages) { language ->
-			BrowseControllerLanguageItem(language, state[language] ?: false, onLanguageChecked)
+		languages.forEach { language ->
+			BrowseControllerLanguageItem(language, state[language.lang] ?: false, onLanguageChecked)
 		}
 	}
 }
@@ -185,13 +208,13 @@ fun BrowseControllerLanguagesContent(
 @Preview
 @Composable
 fun PreviewBrowseControllerLanguageItem() {
-	BrowseControllerLanguageItem("en", false) { _, _ -> }
+	BrowseControllerLanguageItem(LanguageFilter("en"), false) { _, _ -> }
 }
 
 
 @Composable
 fun BrowseControllerLanguageItem(
-	language: String,
+	language: LanguageFilter,
 	state: Boolean,
 	onLanguageChecked: (String, Boolean) -> Unit
 ) {
@@ -199,19 +222,20 @@ fun BrowseControllerLanguageItem(
 		horizontalArrangement = Arrangement.SpaceBetween,
 		modifier = Modifier
 			.fillMaxWidth()
+			.height(56.dp)
+			.clickable(onClick = { onLanguageChecked(language.lang, !state) })
+			.padding(horizontal = 16.dp),
+		verticalAlignment = Alignment.CenterVertically
 	) {
 		Text(
-			text = language,
-			modifier = Modifier.alignByBaseline()
+			text = language.displayLang,
 		)
 		Checkbox(
 			checked = state,
-			onCheckedChange = {
-				onLanguageChecked(language, it)
-			},
+			onCheckedChange = null,
 			modifier = Modifier
-				.alignByBaseline()
-				.padding(bottom = 8.dp)
+
+				.padding(bottom = 8.dp, end = 4.dp)
 		)
 	}
 
@@ -229,17 +253,19 @@ fun BrowseControllerInstalledFilter(state: Boolean, updateState: (Boolean) -> Un
 		horizontalArrangement = Arrangement.SpaceBetween,
 		modifier = Modifier
 			.fillMaxWidth()
+			.height(56.dp)
+			.clickable(onClick = { updateState(!state) })
+			.padding(horizontal = 16.dp),
+		verticalAlignment = Alignment.CenterVertically
 	) {
 		Text(
 			text = stringResource(R.string.controller_browse_filter_only_installed),
-			modifier = Modifier.alignByBaseline()
 		)
 		Checkbox(
 			checked = state,
-			onCheckedChange = updateState,
+			onCheckedChange = null,
 			modifier = Modifier
-				.alignByBaseline()
-				.padding(bottom = 8.dp, end = 12.dp)
+				.padding(end = 4.dp)
 		)
 	}
 }

--- a/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogController.kt
@@ -406,115 +406,113 @@ fun CatalogContent(
 	hasFilters: Boolean,
 	fab: EFabMaintainer
 ) {
-	Column(
+	Box(
 		modifier = Modifier.fillMaxSize(),
 	) {
-		val refreshState = items.loadState.refresh
-		when (refreshState) {
-			is LoadState.NotLoading -> {
-			}
-			LoadState.Loading ->
-				LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-
-			is LoadState.Error ->
-				ErrorContent(
-					refreshState.error.message ?: "Unknown",
-					ErrorAction(R.string.retry) {
-						items.refresh()
-					},
-					stackTrace = refreshState.error.stackTraceToString()
-				)
-		}
-		SwipeRefresh(
-			SwipeRefreshState(false),
-			{
-				items.refresh()
-			},
-		) {
-			val w = LocalConfiguration.current.screenWidthDp
-			val o = LocalConfiguration.current.orientation
-
-			val size =
-				(w / when (o) {
-					Configuration.ORIENTATION_LANDSCAPE -> columnsInH
-					else -> columnsInV
-				}).dp - 8.dp
-
-			val state = rememberLazyGridState()
-			if (hasFilters)
-				syncFABWithCompose(state, fab)
-			LazyVerticalGrid(
-				columns = GridCells.Adaptive(if (cardType != COMPRESSED) size else 400.dp),
-				contentPadding = PaddingValues(
-					bottom = 200.dp,
-					start = 8.dp,
-					end = 8.dp,
-					top = 4.dp
-				),
-				state = state,
-				horizontalArrangement = Arrangement.spacedBy(4.dp),
-				verticalArrangement = Arrangement.spacedBy(4.dp)
+		Column(Modifier.fillMaxHeight()) {
+			SwipeRefresh(
+				state = SwipeRefreshState(false),
+				onRefresh = {
+					items.refresh()
+				},
 			) {
-				itemsIndexed(
-					items,
-					key = { index, item -> item.hashCode() + index }
-				) { _, item ->
-					when (cardType) {
-						NORMAL -> {
-							if (item != null)
-								NovelCardNormalContent(
-									item.title,
-									item.imageURL,
-									onClick = {
-										onClick(item)
-									},
-									onLongClick = {
-										onLongClick(item)
-									},
-									isBookmarked = item.bookmarked
-								)
-						}
-						COMPRESSED -> {
-							if (item != null)
-								NovelCardCompressedContent(
-									item.title,
-									item.imageURL,
-									onClick = {
-										onClick(item)
-									},
-									onLongClick = {
-										onLongClick(item)
-									},
-									isBookmarked = item.bookmarked
-								)
-						}
-						COZY -> {
-							if (item != null)
-								NovelCardCozyContent(
-									item.title,
-									item.imageURL,
-									onClick = {
-										onClick(item)
-									},
-									onLongClick = {
-										onLongClick(item)
-									},
-									isBookmarked = item.bookmarked
-								)
+				val w = LocalConfiguration.current.screenWidthDp
+				val o = LocalConfiguration.current.orientation
+
+				val size =
+					(w / when (o) {
+						Configuration.ORIENTATION_LANDSCAPE -> columnsInH
+						else -> columnsInV
+					}).dp - 8.dp
+
+				val state = rememberLazyGridState()
+				if (hasFilters)
+					syncFABWithCompose(state, fab)
+				LazyVerticalGrid(
+					columns = GridCells.Adaptive(if (cardType != COMPRESSED) size else 400.dp),
+					contentPadding = PaddingValues(
+						bottom = 200.dp,
+						start = 8.dp,
+						end = 8.dp,
+						top = 4.dp
+					),
+					state = state,
+					horizontalArrangement = Arrangement.spacedBy(4.dp),
+					verticalArrangement = Arrangement.spacedBy(4.dp)
+				) {
+					itemsIndexed(
+						items,
+						key = { index, item -> item.hashCode() + index }
+					) { _, item ->
+						when (cardType) {
+							NORMAL -> {
+								if (item != null)
+									NovelCardNormalContent(
+										item.title,
+										item.imageURL,
+										onClick = {
+											onClick(item)
+										},
+										onLongClick = {
+											onLongClick(item)
+										},
+										isBookmarked = item.bookmarked
+									)
+							}
+							COMPRESSED -> {
+								if (item != null)
+									NovelCardCompressedContent(
+										item.title,
+										item.imageURL,
+										onClick = {
+											onClick(item)
+										},
+										onLongClick = {
+											onLongClick(item)
+										},
+										isBookmarked = item.bookmarked
+									)
+							}
+							COZY -> {
+								if (item != null)
+									NovelCardCozyContent(
+										item.title,
+										item.imageURL,
+										onClick = {
+											onClick(item)
+										},
+										onLongClick = {
+											onLongClick(item)
+										},
+										isBookmarked = item.bookmarked
+									)
+							}
 						}
 					}
 				}
 			}
+
+			if (items.loadState.append == LoadState.Loading)
+				LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+
+			if (items.loadState.refresh.endOfPaginationReached && items.loadState.append.endOfPaginationReached) {
+				CatalogContentNoMore()
+			}
+
+			val errorState = items.loadState.refresh
+			if (errorState is LoadState.Error) {
+				ErrorContent(
+					errorState.error.message ?: "Unknown",
+					ErrorAction(R.string.retry) {
+						items.refresh()
+					},
+					stackTrace = errorState.error.stackTraceToString()
+				)
+			}
 		}
 
-		if (items.loadState.append == LoadState.Loading)
+		if (items.loadState.refresh == LoadState.Loading)
 			LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-
-		if (refreshState is LoadState.NotLoading &&
-			items.loadState.append is LoadState.NotLoading
-		) {
-			CatalogContentNoMore()
-		}
 	}
 }
 

--- a/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogueFilterMenu.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogueFilterMenu.kt
@@ -3,11 +3,37 @@ package app.shosetsu.android.ui.catalogue
 import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Card
+import androidx.compose.material.Checkbox
+import androidx.compose.material.Divider
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.IconToggleButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TriStateCheckbox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -122,14 +148,14 @@ fun CatalogFilterMenuFilterListContent(
 	getString: (Filter<String>) -> Flow<String>,
 	setString: (Filter<String>, String) -> Unit
 ) {
-
-	LazyColumn(
+	Column(
 		modifier = Modifier
-			.fillMaxWidth(),
-		contentPadding = PaddingValues(vertical = 16.dp),
+			.fillMaxWidth()
+			.verticalScroll(rememberScrollState()),
 		verticalArrangement = Arrangement.Bottom
 	) {
-		items(list) { filter ->
+		Spacer(Modifier.height(16.dp))
+		list.forEach { filter ->
 			when (filter) {
 				is Filter.Header -> Column {
 					Divider()
@@ -158,6 +184,7 @@ fun CatalogFilterMenuFilterListContent(
 				}
 			}
 		}
+		Spacer(Modifier.height(16.dp))
 	}
 }
 
@@ -196,7 +223,8 @@ fun CatalogFilterMenuFilterListContent(
 		modifier = Modifier.fillMaxWidth()
 	) {
 		Row(
-			modifier = Modifier.fillMaxWidth()
+			modifier = Modifier
+				.fillMaxWidth()
 				.height(56.dp)
 				.clickable(onClick = { collapsed = !collapsed })
 				.padding(horizontal = 16.dp),
@@ -348,7 +376,8 @@ fun CatalogFilterMenuSwitchContent(
 		.collectAsState(initial = false)
 
 	Row(
-		modifier = Modifier.fillMaxWidth()
+		modifier = Modifier
+			.fillMaxWidth()
 			.height(56.dp)
 			.clickable(onClick = { setBoolean(filter, !state) })
 			.padding(horizontal = 16.dp),
@@ -381,7 +410,8 @@ fun CatalogFilterMenuCheckboxContent(
 		.collectAsState(initial = false)
 
 	Row(
-		modifier = Modifier.fillMaxWidth()
+		modifier = Modifier
+			.fillMaxWidth()
 			.height(56.dp)
 			.clickable(onClick = { setBoolean(filter, !state) })
 			.padding(horizontal = 16.dp),
@@ -421,7 +451,8 @@ fun CatalogFilterMenuTriStateContent(
 	}
 
 	Row(
-		modifier = Modifier.fillMaxWidth()
+		modifier = Modifier
+			.fillMaxWidth()
 			.height(56.dp)
 			.clickable(onClick = {
 				setInt(
@@ -467,7 +498,8 @@ fun CatalogFilterMenuDropDownContent(
 	var expanded by remember { mutableStateOf(false) }
 
 	Row(
-		modifier = Modifier.fillMaxWidth()
+		modifier = Modifier
+			.fillMaxWidth()
 			.height(56.dp)
 			.clickable(onClick = { expanded = true })
 			.padding(horizontal = 16.dp),
@@ -542,7 +574,8 @@ fun CatalogFilterMenuRadioGroupContent(
 			,
 	) {
 		Row(
-			modifier = Modifier.fillMaxWidth()
+			modifier = Modifier
+				.fillMaxWidth()
 				.height(56.dp)
 				.clickable(onClick = { expanded = !expanded })
 				.padding(horizontal = 16.dp),
@@ -572,7 +605,8 @@ fun CatalogFilterMenuRadioGroupContent(
 			) {
 				filter.choices.forEachIndexed { index, s ->
 					Row(
-						modifier = Modifier.fillMaxWidth()
+						modifier = Modifier
+							.fillMaxWidth()
 							.height(56.dp)
 							.clickable(onClick = { setInt(filter, index) }),
 						horizontalArrangement = Arrangement.SpaceBetween,

--- a/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogueFilterMenu.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogueFilterMenu.kt
@@ -1,6 +1,7 @@
 package app.shosetsu.android.ui.catalogue
 
 import android.util.Log
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -125,7 +126,7 @@ fun CatalogFilterMenuFilterListContent(
 	LazyColumn(
 		modifier = Modifier
 			.fillMaxWidth(),
-		contentPadding = PaddingValues(16.dp),
+		contentPadding = PaddingValues(vertical = 16.dp),
 		verticalArrangement = Arrangement.Bottom
 	) {
 		items(list) { filter ->
@@ -195,7 +196,10 @@ fun CatalogFilterMenuFilterListContent(
 		modifier = Modifier.fillMaxWidth()
 	) {
 		Row(
-			modifier = Modifier.fillMaxWidth(),
+			modifier = Modifier.fillMaxWidth()
+				.height(56.dp)
+				.clickable(onClick = { collapsed = !collapsed })
+				.padding(horizontal = 16.dp),
 			horizontalArrangement = Arrangement.SpaceBetween,
 			verticalAlignment = Alignment.CenterVertically
 		) {
@@ -213,11 +217,11 @@ fun CatalogFilterMenuFilterListContent(
 			}
 		}
 
-		if (!collapsed) {
+		AnimatedVisibility(!collapsed) {
 			Column(
 				modifier = Modifier
 					.fillMaxWidth()
-					.padding(start = 8.dp, end = 8.dp)
+					.padding(horizontal = 16.dp)
 			) {
 				list.forEach { filter ->
 					when (filter) {
@@ -311,9 +315,10 @@ fun CatalogFilterMenuTextContent(
 	val text by getString(filter)
 		.collectAsState(initial = "")
 
-	TextField(
+	OutlinedTextField(
 		modifier = Modifier
 			.fillMaxWidth()
+			.padding(horizontal = 16.dp)
 			.padding(bottom = 8.dp),
 		value = text,
 		onValueChange = { setString(filter, it) },
@@ -343,13 +348,17 @@ fun CatalogFilterMenuSwitchContent(
 		.collectAsState(initial = false)
 
 	Row(
-		modifier = Modifier.fillMaxWidth(),
-		horizontalArrangement = Arrangement.SpaceBetween
+		modifier = Modifier.fillMaxWidth()
+			.height(56.dp)
+			.clickable(onClick = { setBoolean(filter, !state) })
+			.padding(horizontal = 16.dp),
+		horizontalArrangement = Arrangement.SpaceBetween,
+		verticalAlignment = Alignment.CenterVertically
 	) {
 		Text(text = filter.name)
 		Switch(
 			checked = state,
-			onCheckedChange = { setBoolean(filter, it) }
+			onCheckedChange = null
 		)
 	}
 }
@@ -372,13 +381,17 @@ fun CatalogFilterMenuCheckboxContent(
 		.collectAsState(initial = false)
 
 	Row(
-		modifier = Modifier.fillMaxWidth(),
-		horizontalArrangement = Arrangement.SpaceBetween
+		modifier = Modifier.fillMaxWidth()
+			.height(56.dp)
+			.clickable(onClick = { setBoolean(filter, !state) })
+			.padding(horizontal = 16.dp),
+		horizontalArrangement = Arrangement.SpaceBetween,
+		verticalAlignment = Alignment.CenterVertically
 	) {
 		Text(text = filter.name)
 		Checkbox(
 			checked = state,
-			onCheckedChange = { setBoolean(filter, it) }
+			onCheckedChange = null
 		)
 	}
 }
@@ -408,13 +421,9 @@ fun CatalogFilterMenuTriStateContent(
 	}
 
 	Row(
-		modifier = Modifier.fillMaxWidth(),
-		horizontalArrangement = Arrangement.SpaceBetween
-	) {
-		Text(text = filter.name)
-		TriStateCheckbox(
-			state = convertedState,
-			onClick = {
+		modifier = Modifier.fillMaxWidth()
+			.height(56.dp)
+			.clickable(onClick = {
 				setInt(
 					filter,
 					when (triState) {
@@ -424,7 +433,15 @@ fun CatalogFilterMenuTriStateContent(
 						else -> Filter.TriState.STATE_IGNORED
 					}
 				)
-			}
+			})
+			.padding(horizontal = 16.dp),
+		horizontalArrangement = Arrangement.SpaceBetween,
+		verticalAlignment = Alignment.CenterVertically
+	) {
+		Text(text = filter.name)
+		TriStateCheckbox(
+			state = convertedState,
+			onClick = null
 		)
 	}
 }
@@ -450,7 +467,10 @@ fun CatalogFilterMenuDropDownContent(
 	var expanded by remember { mutableStateOf(false) }
 
 	Row(
-		modifier = Modifier.fillMaxWidth(),
+		modifier = Modifier.fillMaxWidth()
+			.height(56.dp)
+			.clickable(onClick = { expanded = true })
+			.padding(horizontal = 16.dp),
 		horizontalArrangement = Arrangement.SpaceBetween,
 		verticalAlignment = Alignment.CenterVertically
 	) {
@@ -458,13 +478,11 @@ fun CatalogFilterMenuDropDownContent(
 
 
 		Row(
+			modifier = Modifier.fillMaxHeight(),
 			verticalAlignment = Alignment.CenterVertically,
 		) {
 			Text(
 				text = AnnotatedString(filter.choices[selection]),
-				modifier = Modifier.clickable(onClick = {
-					expanded = true
-				})
 			)
 			IconToggleButton(
 				onCheckedChange = {
@@ -520,10 +538,14 @@ fun CatalogFilterMenuRadioGroupContent(
 	var expanded by remember { mutableStateOf(true) }
 
 	Column(
-		modifier = Modifier.fillMaxWidth(),
+		modifier = Modifier.fillMaxWidth()
+			,
 	) {
 		Row(
-			modifier = Modifier.fillMaxWidth(),
+			modifier = Modifier.fillMaxWidth()
+				.height(56.dp)
+				.clickable(onClick = { expanded = !expanded })
+				.padding(horizontal = 16.dp),
 			horizontalArrangement = Arrangement.SpaceBetween,
 			verticalAlignment = Alignment.CenterVertically
 		) {
@@ -542,7 +564,7 @@ fun CatalogFilterMenuRadioGroupContent(
 			}
 		}
 
-		if (expanded) {
+		AnimatedVisibility(expanded) {
 			Column(
 				modifier = Modifier
 					.fillMaxWidth()
@@ -550,13 +572,16 @@ fun CatalogFilterMenuRadioGroupContent(
 			) {
 				filter.choices.forEachIndexed { index, s ->
 					Row(
-						modifier = Modifier.fillMaxWidth(),
-						horizontalArrangement = Arrangement.SpaceBetween
+						modifier = Modifier.fillMaxWidth()
+							.height(56.dp)
+							.clickable(onClick = { setInt(filter, index) }),
+						horizontalArrangement = Arrangement.SpaceBetween,
+						verticalAlignment = Alignment.CenterVertically
 					) {
 						Text(text = s)
 						RadioButton(
 							selected = index == selection,
-							onClick = { setInt(filter, index) }
+							onClick = null
 						)
 					}
 				}
@@ -576,13 +601,14 @@ fun CatalogFilterMenuControlContent(
 		shape = RectangleShape
 	) {
 		Row(
-			horizontalArrangement = Arrangement.SpaceEvenly
+			horizontalArrangement = Arrangement.SpaceEvenly,
+			verticalAlignment = Alignment.CenterVertically
 		) {
-			TextButton(onClick = { resetFilter() }, contentPadding = PaddingValues(8.dp)) {
+			TextButton(onClick = resetFilter, contentPadding = PaddingValues(8.dp)) {
 				Text(text = stringResource(id = R.string.reset))
 			}
 
-			TextButton(onClick = { applyFilter() }, contentPadding = PaddingValues(8.dp)) {
+			TextButton(onClick = applyFilter, contentPadding = PaddingValues(8.dp)) {
 				Text(text = stringResource(id = R.string.apply))
 			}
 		}

--- a/android/src/main/java/app/shosetsu/android/ui/extensionsConfigure/ConfigureExtension.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/extensionsConfigure/ConfigureExtension.kt
@@ -5,17 +5,30 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.*
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TriStateCheckbox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.state.ToggleableState
@@ -25,19 +38,22 @@ import app.shosetsu.android.common.consts.BundleKeys.BUNDLE_EXTENSION
 import app.shosetsu.android.common.enums.TriStateState
 import app.shosetsu.android.common.ext.viewModel
 import app.shosetsu.android.domain.model.local.FilterEntity
-import app.shosetsu.android.domain.model.local.InstalledExtensionEntity
+import app.shosetsu.android.view.compose.ImageLoadingError
 import app.shosetsu.android.view.compose.ShosetsuCompose
 import app.shosetsu.android.view.compose.setting.DropdownSettingContent
 import app.shosetsu.android.view.compose.setting.StringSettingContent
 import app.shosetsu.android.view.compose.setting.SwitchSettingContent
 import app.shosetsu.android.view.controller.ShosetsuController
 import app.shosetsu.android.view.controller.base.CollapsedToolBarController
+import app.shosetsu.android.view.uimodels.model.InstalledExtensionUI
 import app.shosetsu.android.viewmodel.abstracted.AExtensionConfigureViewModel
 import app.shosetsu.lib.ExtensionType
 import app.shosetsu.lib.Novel
 import app.shosetsu.lib.Version
-import coil.compose.rememberAsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
 import com.github.doomsdayrs.apps.shosetsu.R
+import com.google.accompanist.placeholder.material.placeholder
 import kotlin.random.Random
 
 /*
@@ -285,7 +301,7 @@ fun SettingsItemAsCompose(
 @Composable
 fun PreviewConfigureExtensionHeaderContent() {
 	ConfigureExtensionHeaderContent(
-		InstalledExtensionEntity(
+		InstalledExtensionUI(
 			1,
 			1,
 			"This is an extension",
@@ -305,7 +321,7 @@ fun PreviewConfigureExtensionHeaderContent() {
 
 @Composable
 fun ConfigureExtensionHeaderContent(
-	extension: InstalledExtensionEntity,
+	extension: InstalledExtensionUI,
 	onUninstall: () -> Unit
 ) {
 	Card {
@@ -317,15 +333,24 @@ fun ConfigureExtensionHeaderContent(
 			Row(
 				verticalAlignment = Alignment.CenterVertically
 			) {
-				Icon(
-					painter = if (extension.imageURL.isNotEmpty()) {
-						rememberAsyncImagePainter(extension.imageURL)
-					} else {
-						painterResource(R.drawable.broken_image)
-					},
-					stringResource(R.string.extension_image_desc),
-					modifier = Modifier.size(100.dp)
-				)
+				if (extension.imageURL.isNotEmpty()) {
+					SubcomposeAsyncImage(
+						ImageRequest.Builder(LocalContext.current)
+							.data(extension.imageURL)
+							.crossfade(true)
+							.build(),
+						contentDescription = stringResource(R.string.extension_image_desc),
+						modifier = Modifier.size(100.dp),
+						error = {
+							ImageLoadingError()
+						},
+						loading = {
+							Box(Modifier.placeholder(true))
+						}
+					)
+				} else {
+					ImageLoadingError(Modifier.size(100.dp))
+				}
 
 				Column {
 					Text(extension.name)
@@ -335,7 +360,7 @@ fun ConfigureExtensionHeaderContent(
 						Text(extension.id.toString())
 						Text(extension.fileName, modifier = Modifier.padding(start = 16.dp))
 					}
-					Text(extension.lang)
+					Text(extension.displayLang)
 				}
 			}
 

--- a/android/src/main/java/app/shosetsu/android/ui/migration/MigrationController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/migration/MigrationController.kt
@@ -5,19 +5,40 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.material.Card
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -25,13 +46,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.shosetsu.android.common.ext.viewModel
+import app.shosetsu.android.view.compose.ImageLoadingError
 import app.shosetsu.android.view.compose.ShosetsuCompose
 import app.shosetsu.android.view.controller.ShosetsuController
 import app.shosetsu.android.view.uimodels.model.MigrationExtensionUI
 import app.shosetsu.android.view.uimodels.model.MigrationNovelUI
 import app.shosetsu.android.viewmodel.abstracted.AMigrationViewModel
-import coil.compose.rememberAsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
 import com.github.doomsdayrs.apps.shosetsu.R
+import com.google.accompanist.placeholder.material.placeholder
 
 /*
  * This file is part of Shosetsu.
@@ -206,17 +230,24 @@ fun MigrationExtensionItemContent(
 		Row(
 			verticalAlignment = Alignment.CenterVertically,
 		) {
-			Image(
-				painter = if (item.imageURL.isNotEmpty()) {
-					rememberAsyncImagePainter(item.imageURL)
-				} else {
-					painterResource(R.drawable.broken_image)
-				},
-				contentDescription = null,
-				modifier = Modifier
-					.height(64.dp)
-					.aspectRatio(1f)
-			)
+			if (item.imageURL.isNotEmpty()) {
+				SubcomposeAsyncImage(
+					ImageRequest.Builder(LocalContext.current)
+						.data(item.imageURL)
+						.crossfade(true)
+						.build(),
+					contentDescription = null,
+					modifier = Modifier.size(64.dp),
+					error = {
+						ImageLoadingError()
+					},
+					loading = {
+						Box(Modifier.placeholder(true))
+					}
+				)
+			} else {
+				ImageLoadingError(Modifier.size(64.dp))
+			}
 			Text(
 				text = item.name,
 				modifier = Modifier.padding(end = 16.dp)
@@ -310,28 +341,36 @@ fun MigrationNovelItemContent(item: MigrationNovelUI, onClick: (MigrationNovelUI
 	) {
 		val blackTrans = colorResource(id = R.color.black_trans)
 		Box {
-			Image(
-				painter = if (item.imageURL.isNotEmpty()) {
-					rememberAsyncImagePainter(item.imageURL)
-				} else {
-					painterResource(R.drawable.broken_image)
-				},
-				contentDescription = null,
-				modifier = Modifier
-					.fillMaxSize()
-					.drawWithContent {
-
-						drawContent()
-						drawRect(
-							Brush.verticalGradient(
-								colors = listOf(
-									Color.Transparent,
-									blackTrans
-								),
-							)
+			val modifier = Modifier.fillMaxSize()
+				.drawWithContent {
+					drawContent()
+					drawRect(
+						Brush.verticalGradient(
+							colors = listOf(
+								Color.Transparent,
+								blackTrans
+							),
 						)
+					)
+				}
+			if (item.imageURL.isNotEmpty()) {
+				SubcomposeAsyncImage(
+					ImageRequest.Builder(LocalContext.current)
+						.data(item.imageURL)
+						.crossfade(true)
+						.build(),
+					contentDescription = null,
+					modifier = modifier,
+					error = {
+						ImageLoadingError()
 					},
-			)
+					loading = {
+						Box(Modifier.placeholder(true))
+					}
+				)
+			} else {
+				ImageLoadingError(modifier)
+			}
 
 			Text(
 				text = item.title,

--- a/android/src/main/java/app/shosetsu/android/ui/novel/NovelController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/novel/NovelController.kt
@@ -40,7 +40,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
@@ -1119,10 +1118,7 @@ fun NovelInfoCoverContent(
 			.build(),
 		stringResource(string.controller_novel_info_image),
 		modifier = modifier
-			.aspectRatio(coverRatio)
-			.padding(top = 8.dp, start = 4.dp)
-			.clickable(onClick = onClick)
-			.clip(RoundedCornerShape(16.dp)),
+			.clickable(onClick = onClick),
 		error = {
 			ImageLoadingError()
 		},
@@ -1190,6 +1186,9 @@ fun NovelInfoHeaderContent(
 					NovelInfoCoverContent(
 						novelInfo.imageURL,
 						modifier = Modifier.fillMaxWidth(.35f)
+							.aspectRatio(coverRatio)
+							.padding(top = 8.dp, start = 4.dp)
+							.clip(MaterialTheme.shapes.medium)
 					) {
 						isCoverClicked = true
 					}

--- a/android/src/main/java/app/shosetsu/android/ui/novel/NovelController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/novel/NovelController.kt
@@ -1109,6 +1109,7 @@ fun PreviewHeaderContent() {
 fun NovelInfoCoverContent(
 	imageURL: String,
 	modifier: Modifier = Modifier,
+	contentScale: ContentScale = ContentScale.Fit,
 	onClick: () -> Unit,
 ) {
 	SubcomposeAsyncImage(
@@ -1119,6 +1120,7 @@ fun NovelInfoCoverContent(
 		stringResource(string.controller_novel_info_image),
 		modifier = modifier
 			.clickable(onClick = onClick),
+		contentScale = contentScale,
 		error = {
 			ImageLoadingError()
 		},
@@ -1188,7 +1190,8 @@ fun NovelInfoHeaderContent(
 						modifier = Modifier.fillMaxWidth(.35f)
 							.aspectRatio(coverRatio)
 							.padding(top = 8.dp, start = 4.dp)
-							.clip(MaterialTheme.shapes.medium)
+							.clip(MaterialTheme.shapes.medium),
+						contentScale = ContentScale.Crop
 					) {
 						isCoverClicked = true
 					}

--- a/android/src/main/java/app/shosetsu/android/ui/search/SearchController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/search/SearchController.kt
@@ -1,10 +1,23 @@
 package app.shosetsu.android.ui.search
 
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.widget.SearchView
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
@@ -19,7 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,14 +46,25 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemsIndexed
 import app.shosetsu.android.common.consts.BundleKeys
-import app.shosetsu.android.common.ext.*
-import app.shosetsu.android.view.compose.*
+import app.shosetsu.android.common.ext.logE
+import app.shosetsu.android.common.ext.makeSnackBar
+import app.shosetsu.android.common.ext.navigateSafely
+import app.shosetsu.android.common.ext.setShosetsuTransition
+import app.shosetsu.android.common.ext.viewModel
+import app.shosetsu.android.view.compose.ImageLoadingError
+import app.shosetsu.android.view.compose.NovelCardCozyContent
+import app.shosetsu.android.view.compose.NovelCardNormalContent
+import app.shosetsu.android.view.compose.PlaceholderNovelCardCozyContent
+import app.shosetsu.android.view.compose.PlaceholderNovelCardNormalContent
+import app.shosetsu.android.view.compose.ShosetsuCompose
 import app.shosetsu.android.view.controller.ShosetsuController
 import app.shosetsu.android.view.uimodels.model.catlog.ACatalogNovelUI
 import app.shosetsu.android.view.uimodels.model.search.SearchRowUI
 import app.shosetsu.android.viewmodel.abstracted.ASearchViewModel
-import coil.compose.rememberAsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
 import com.github.doomsdayrs.apps.shosetsu.R
+import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.coroutines.flow.Flow
@@ -324,14 +348,19 @@ fun SearchRowContent(
 			modifier = Modifier.padding(8.dp),
 			verticalAlignment = Alignment.CenterVertically
 		) {
-			Image(
-				if (!row.imageURL.isNullOrEmpty()) {
-					rememberAsyncImagePainter(row.imageURL)
-				} else {
-					painterResource(R.drawable.library)
-				},
+			SubcomposeAsyncImage(
+				ImageRequest.Builder(LocalContext.current)
+					.data(if (!row.imageURL.isNullOrEmpty()) row.imageURL else R.drawable.library)
+					.crossfade(true)
+					.build(),
 				contentDescription = row.name,
-				modifier = Modifier.size(32.dp)
+				modifier = Modifier.size(32.dp),
+				error = {
+					ImageLoadingError()
+				},
+				loading = {
+					Box(Modifier.placeholder(true))
+				}
 			)
 			Text(row.name, modifier = Modifier.padding(start = 8.dp))
 		}
@@ -339,7 +368,7 @@ fun SearchRowContent(
 
 		LazyRow(
 			horizontalArrangement = Arrangement.spacedBy(4.dp),
-			contentPadding = PaddingValues(start = 4.dp)
+			contentPadding = PaddingValues(horizontal = 4.dp)
 		) {
 			items()
 		}

--- a/android/src/main/java/app/shosetsu/android/ui/settings/sub/AdvancedSettings.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/settings/sub/AdvancedSettings.kt
@@ -17,8 +17,19 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import app.shosetsu.android.common.SettingKey.*
-import app.shosetsu.android.common.ext.*
+import app.shosetsu.android.common.SettingKey.AppTheme
+import app.shosetsu.android.common.SettingKey.AutoBookmarkFromQR
+import app.shosetsu.android.common.SettingKey.ExposeTrueChapterDelete
+import app.shosetsu.android.common.SettingKey.LogToFile
+import app.shosetsu.android.common.SettingKey.RequireDoubleBackToExit
+import app.shosetsu.android.common.SettingKey.VerifyCheckSum
+import app.shosetsu.android.common.ext.launchIO
+import app.shosetsu.android.common.ext.launchUI
+import app.shosetsu.android.common.ext.logE
+import app.shosetsu.android.common.ext.logI
+import app.shosetsu.android.common.ext.logV
+import app.shosetsu.android.common.ext.makeSnackBar
+import app.shosetsu.android.common.ext.viewModel
 import app.shosetsu.android.view.compose.ShosetsuCompose
 import app.shosetsu.android.view.compose.setting.ButtonSettingContent
 import app.shosetsu.android.view.compose.setting.DropdownSettingContent
@@ -152,8 +163,6 @@ fun AdvancedSettingsContent(
 	LazyColumn(
 		contentPadding = PaddingValues(
 			top = 16.dp,
-			start = 16.dp,
-			end = 16.dp,
 			bottom = 64.dp
 		),
 		verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/android/src/main/java/app/shosetsu/android/ui/settings/sub/DownloadSettings.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/settings/sub/DownloadSettings.kt
@@ -17,7 +17,11 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.shosetsu.android.common.SettingKey
-import app.shosetsu.android.common.ext.*
+import app.shosetsu.android.common.ext.launchUI
+import app.shosetsu.android.common.ext.makeSnackBar
+import app.shosetsu.android.common.ext.setOnDismissed
+import app.shosetsu.android.common.ext.toast
+import app.shosetsu.android.common.ext.viewModel
 import app.shosetsu.android.view.compose.ShosetsuCompose
 import app.shosetsu.android.view.compose.setting.SliderSettingContent
 import app.shosetsu.android.view.compose.setting.SwitchSettingContent
@@ -125,7 +129,7 @@ fun DownloadSettingsContent(
 	performFileSearch: () -> Unit
 ) {
 	LazyColumn(
-		contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 64.dp),
+		contentPadding = PaddingValues(top = 16.dp, bottom = 64.dp),
 		verticalArrangement = Arrangement.spacedBy(8.dp)
 	) {
 		item {

--- a/android/src/main/java/app/shosetsu/android/ui/settings/sub/ReaderSettings.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/settings/sub/ReaderSettings.kt
@@ -9,7 +9,12 @@ import android.view.ViewGroup
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -30,7 +35,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.shosetsu.android.common.SettingKey.*
+import app.shosetsu.android.common.SettingKey.ChaptersResumeFirstUnread
+import app.shosetsu.android.common.SettingKey.ReaderKeepScreenOn
+import app.shosetsu.android.common.SettingKey.ReaderMarkReadAsReading
+import app.shosetsu.android.common.SettingKey.ReaderTextAlignment
+import app.shosetsu.android.common.SettingKey.ReaderTheme
+import app.shosetsu.android.common.SettingKey.ReadingMarkingType
 import app.shosetsu.android.common.consts.SELECTED_STROKE_WIDTH
 import app.shosetsu.android.common.enums.MarkingType
 import app.shosetsu.android.common.ext.launchIO
@@ -44,7 +54,14 @@ import app.shosetsu.android.view.compose.setting.GenericBottomSettingLayout
 import app.shosetsu.android.view.compose.setting.SwitchSettingContent
 import app.shosetsu.android.view.controller.ShosetsuController
 import app.shosetsu.android.viewmodel.abstracted.settings.AReaderSettingsViewModel
-import app.shosetsu.android.viewmodel.impl.settings.*
+import app.shosetsu.android.viewmodel.impl.settings.doubleTapFocus
+import app.shosetsu.android.viewmodel.impl.settings.doubleTapSystem
+import app.shosetsu.android.viewmodel.impl.settings.invertChapterSwipeOption
+import app.shosetsu.android.viewmodel.impl.settings.paragraphIndentOption
+import app.shosetsu.android.viewmodel.impl.settings.paragraphSpacingOption
+import app.shosetsu.android.viewmodel.impl.settings.showReaderDivider
+import app.shosetsu.android.viewmodel.impl.settings.stringAsHtmlOption
+import app.shosetsu.android.viewmodel.impl.settings.textSizeOption
 import com.github.doomsdayrs.apps.shosetsu.R
 
 /*
@@ -110,7 +127,7 @@ fun ReaderSettingsContent(
 ) {
 
 	LazyColumn(
-		contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 64.dp),
+		contentPadding = PaddingValues(top = 16.dp, bottom = 64.dp),
 		verticalArrangement = Arrangement.spacedBy(8.dp)
 	) {
 		//TODO Text Preview at top

--- a/android/src/main/java/app/shosetsu/android/ui/settings/sub/UpdateSettings.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/settings/sub/UpdateSettings.kt
@@ -70,7 +70,7 @@ class UpdateSettings : ShosetsuController() {
 @Composable
 fun UpdateSettingsContent(viewModel: AUpdateSettingsViewModel) {
 	LazyColumn(
-		contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 64.dp, top = 16.dp),
+		contentPadding = PaddingValues(bottom = 64.dp, top = 16.dp),
 		verticalArrangement = Arrangement.spacedBy(8.dp)
 	) {
 		item {

--- a/android/src/main/java/app/shosetsu/android/ui/settings/sub/ViewSettings.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/settings/sub/ViewSettings.kt
@@ -12,13 +12,21 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import app.shosetsu.android.common.SettingKey.*
+import app.shosetsu.android.common.SettingKey.ChapterColumnsInLandscape
+import app.shosetsu.android.common.SettingKey.ChapterColumnsInPortait
+import app.shosetsu.android.common.SettingKey.NavStyle
+import app.shosetsu.android.common.SettingKey.SelectedNovelCardType
 import app.shosetsu.android.common.ext.launchIO
 import app.shosetsu.android.common.ext.launchUI
 import app.shosetsu.android.common.ext.viewModel
@@ -89,8 +97,6 @@ fun ViewSettingsContent(viewModel: AViewSettingsViewModel, finishActivity: () ->
 	LazyColumn(
 		contentPadding = PaddingValues(
 			top = 16.dp,
-			start = 16.dp,
-			end = 16.dp,
 			bottom = 64.dp
 		),
 		verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/android/src/main/java/app/shosetsu/android/ui/settings/sub/ViewSettings.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/settings/sub/ViewSettings.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import app.shosetsu.android.common.SettingKey.ChapterColumnsInLandscape
 import app.shosetsu.android.common.SettingKey.ChapterColumnsInPortait
 import app.shosetsu.android.common.SettingKey.NavStyle
+import app.shosetsu.android.common.SettingKey.NovelBadgeToast
 import app.shosetsu.android.common.SettingKey.SelectedNovelCardType
 import app.shosetsu.android.common.ext.launchIO
 import app.shosetsu.android.common.ext.launchUI
@@ -135,6 +136,17 @@ fun ViewSettingsContent(viewModel: AViewSettingsViewModel, finishActivity: () ->
 				key = SelectedNovelCardType,
 				modifier = Modifier
 					.fillMaxWidth()
+			)
+		}
+
+
+		item {
+			SwitchSettingContent(
+				title = stringResource(R.string.novel_badge_toast_title),
+				description = stringResource(R.string.novel_badge_toast_desc),
+				repo = viewModel.settingsRepo,
+				key = NovelBadgeToast,
+				modifier = Modifier.fillMaxWidth()
 			)
 		}
 

--- a/android/src/main/java/app/shosetsu/android/ui/updates/UpdatesController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/updates/UpdatesController.kt
@@ -141,7 +141,7 @@ fun UpdatesContent(
 		} else {
 			SwipeRefresh(rememberSwipeRefreshState(false), onRefresh) {
 				LazyColumn(
-					contentPadding = PaddingValues(bottom = 112.dp, top = 4.dp),
+					contentPadding = PaddingValues(bottom = 112.dp),
 					verticalArrangement = Arrangement.spacedBy(4.dp)
 				) {
 					items.forEach { (header, updateItems) ->
@@ -247,7 +247,10 @@ fun UpdateItemContent(updateUI: UpdatesUI, onClick: () -> Unit) {
 
 @Composable
 fun UpdateHeaderItemContent(dateTime: DateTime) {
-	Surface(modifier = Modifier.fillMaxWidth()) {
+	Surface(
+		modifier = Modifier.fillMaxWidth(),
+		elevation = 2.dp
+	) {
 		val context = LocalContext.current
 		val text = remember(dateTime, context) {
 			when (dateTime) {

--- a/android/src/main/java/app/shosetsu/android/view/compose/ImageLoadingError.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/ImageLoadingError.kt
@@ -13,6 +13,23 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.github.doomsdayrs.apps.shosetsu.R
 
+/*
+ * This file is part of shosetsu.
+ *
+ * shosetsu is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * shosetsu is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with shosetsu.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 @Composable
 fun ImageLoadingError(modifier: Modifier = Modifier) {
     Box(

--- a/android/src/main/java/app/shosetsu/android/view/compose/ImageLoadingError.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/ImageLoadingError.kt
@@ -1,0 +1,31 @@
+package app.shosetsu.android.view.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.github.doomsdayrs.apps.shosetsu.R
+
+@Composable
+fun ImageLoadingError(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier then Modifier
+            .fillMaxSize()
+            .background(Color(0x1F888888)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painterResource(R.drawable.broken_image),
+            contentDescription = null,
+            tint = Color(0x1F888888),
+            modifier = Modifier.size(24.dp)
+        )
+    }
+}

--- a/android/src/main/java/app/shosetsu/android/view/compose/NovelCard.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/NovelCard.kt
@@ -144,18 +144,24 @@ fun NovelCardNormalContent(
 					}
 					.alpha(if (isPlaceholder) 0.0f else 1.0f)
 			)
-			Text(
-				title,
-				modifier = Modifier
+			Box(
+				Modifier
 					.align(Alignment.BottomCenter)
-					.placeholder(visible = isPlaceholder)
+                    .fillMaxWidth()
 					.padding(4.dp),
-				textAlign = TextAlign.Center,
-				color = Color.White,
-				overflow = TextOverflow.Ellipsis,
-				maxLines = 3,
-				fontSize = 14.sp
-			)
+				contentAlignment = Alignment.Center
+			) {
+				Text(
+					title,
+					modifier = Modifier
+						.placeholder(visible = isPlaceholder),
+					textAlign = TextAlign.Center,
+					color = Color.White,
+					overflow = TextOverflow.Ellipsis,
+					maxLines = 3,
+					fontSize = 14.sp
+				)
+			}
 			if (overlay != null)
 				overlay()
 		}
@@ -236,16 +242,22 @@ fun NovelCardCozyContent(
 			}
 		}
 
-		Text(
-			title,
-			modifier = Modifier
-				.placeholder(visible = isPlaceholder)
+		Box(
+			Modifier
+				.fillMaxWidth()
 				.padding(4.dp),
-			textAlign = TextAlign.Center,
-			overflow = TextOverflow.Ellipsis,
-			maxLines = 3,
-			fontSize = 14.sp
-		)
+			contentAlignment = Alignment.Center
+		) {
+			Text(
+				title,
+				modifier = Modifier
+					.placeholder(visible = isPlaceholder),
+				textAlign = TextAlign.Center,
+				overflow = TextOverflow.Ellipsis,
+				maxLines = 3,
+				fontSize = 14.sp
+			)
+		}
 	}
 }
 

--- a/android/src/main/java/app/shosetsu/android/view/compose/NovelCard.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/NovelCard.kt
@@ -61,7 +61,7 @@ import com.google.accompanist.placeholder.material.placeholder
  * @author Doomsdayrs
  */
 
-const val coverRatio = 12.8F / 18.2F
+const val coverRatio = 0.7F
 
 @Composable
 fun PlaceholderNovelCardNormalContent() {

--- a/android/src/main/java/app/shosetsu/android/view/compose/NovelCard.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/NovelCard.kt
@@ -1,11 +1,19 @@
 package app.shosetsu.android.view.compose
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,8 +31,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import app.shosetsu.android.common.consts.SELECTED_STROKE_WIDTH
-import coil.compose.AsyncImage
+import androidx.compose.ui.unit.sp
+import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import com.github.doomsdayrs.apps.shosetsu.R
 import com.google.accompanist.placeholder.material.placeholder
@@ -52,6 +60,8 @@ import com.google.accompanist.placeholder.material.placeholder
  * @since 14 / 05 / 2022
  * @author Doomsdayrs
  */
+
+const val coverRatio = 12.8F / 18.2F
 
 @Composable
 fun PlaceholderNovelCardNormalContent() {
@@ -91,37 +101,30 @@ fun NovelCardNormalContent(
 ) {
 	Card(
 		modifier = Modifier
+			.selectedOutline(isSelected)
 			.combinedClickable(
 				onClick = onClick,
 				onLongClick = onLongClick
 			)
 			.alpha(if (isBookmarked) .5f else 1f),
-		border = if (isSelected) {
-			BorderStroke(
-				width = (SELECTED_STROKE_WIDTH / 2).dp,
-				color = MaterialTheme.colors.primary
-			)
-		} else {
-			null
-		}
 	) {
 		Box {
-			AsyncImage(
-				ImageRequest.Builder(LocalContext.current)
-					.data(imageURL)
-					.error(R.drawable.broken_image)
-					.build(),
+			SubcomposeAsyncImage(
+				imageURL,
 				stringResource(R.string.controller_novel_info_image),
 				modifier = Modifier
 					.fillMaxSize()
-					.aspectRatio(.75f)
+					.aspectRatio(coverRatio)
 					.placeholder(visible = isPlaceholder),
-				contentScale = ContentScale.Crop
+				contentScale = ContentScale.Crop,
+				error = {
+					ImageLoadingError()
+				}
 			)
 
 			Box(
 				modifier = Modifier
-					.aspectRatio(.75f)
+					.aspectRatio(coverRatio)
 					.fillMaxSize()
 					.drawWithCache {
 						onDrawWithContent {
@@ -150,7 +153,8 @@ fun NovelCardNormalContent(
 				textAlign = TextAlign.Center,
 				color = Color.White,
 				overflow = TextOverflow.Ellipsis,
-				maxLines = 3
+				maxLines = 3,
+				fontSize = 14.sp
 			)
 			if (overlay != null)
 				overlay()
@@ -196,6 +200,7 @@ fun NovelCardCozyContent(
 ) {
 	Column(
 		modifier = Modifier
+			.selectedOutline(isSelected)
 			.alpha(if (isBookmarked) .5f else 1f)
 	) {
 		Card(
@@ -204,27 +209,25 @@ fun NovelCardCozyContent(
 					onClick = onClick,
 					onLongClick = onLongClick
 				),
-			border = if (isSelected) {
-				BorderStroke(
-					width = (SELECTED_STROKE_WIDTH / 2).dp,
-					color = MaterialTheme.colors.primary
-				)
-			} else {
-				null
-			}
 		) {
 			Box {
-				AsyncImage(
+				SubcomposeAsyncImage(
 					ImageRequest.Builder(LocalContext.current)
 						.data(imageURL)
-						.error(R.drawable.broken_image)
+						.crossfade(true)
 						.build(),
 					stringResource(R.string.controller_novel_info_image),
 					modifier = Modifier
 						.fillMaxSize()
-						.aspectRatio(.75f)
+						.aspectRatio(coverRatio)
 						.placeholder(visible = isPlaceholder),
-					contentScale = ContentScale.Crop
+					contentScale = ContentScale.Crop,
+					error = {
+						ImageLoadingError()
+					},
+					loading = {
+						Box(Modifier.placeholder(true))
+					}
 				)
 
 				if (overlay != null)
@@ -240,7 +243,8 @@ fun NovelCardCozyContent(
 				.padding(4.dp),
 			textAlign = TextAlign.Center,
 			overflow = TextOverflow.Ellipsis,
-			maxLines = 3
+			maxLines = 3,
+			fontSize = 14.sp
 		)
 	}
 }
@@ -273,19 +277,12 @@ fun NovelCardCompressedContent(
 ) {
 	Card(
 		modifier = Modifier
+			.selectedOutline(isSelected)
 			.combinedClickable(
 				onClick = onClick,
 				onLongClick = onLongClick
 			)
 			.alpha(if (isBookmarked) .5f else 1f),
-		border = if (isSelected) {
-			BorderStroke(
-				width = (SELECTED_STROKE_WIDTH / 2).dp,
-				color = MaterialTheme.colors.primary
-			)
-		} else {
-			null
-		}
 	) {
 		Box {
 			Row(
@@ -297,17 +294,22 @@ fun NovelCardCompressedContent(
 					verticalAlignment = Alignment.CenterVertically,
 					modifier = Modifier.fillMaxSize(.70f)
 				) {
-					AsyncImage(
+					SubcomposeAsyncImage(
 						ImageRequest.Builder(LocalContext.current)
 							.data(imageURL)
-							.error(R.drawable.broken_image)
+							.crossfade(true)
 							.build(),
 						stringResource(R.string.controller_novel_info_image),
 						modifier = Modifier
 							.width(64.dp)
-							.aspectRatio(1.0f)
-							.placeholder(visible = isPlaceholder),
-						contentScale = ContentScale.Crop
+							.aspectRatio(1.0f),
+						contentScale = ContentScale.Crop,
+						error = {
+							ImageLoadingError()
+						},
+						loading = {
+							Box(Modifier.placeholder(true))
+						}
 					)
 
 					Text(

--- a/android/src/main/java/app/shosetsu/android/view/compose/Selected.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/Selected.kt
@@ -9,6 +9,23 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.dp
 
+/*
+ * This file is part of shosetsu.
+ *
+ * shosetsu is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * shosetsu is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with shosetsu.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 fun Modifier.selectedOutline(isSelected: Boolean) = composed {
     val secondary = MaterialTheme.colors.secondary
     if (isSelected) {

--- a/android/src/main/java/app/shosetsu/android/view/compose/Selected.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/Selected.kt
@@ -1,0 +1,30 @@
+package app.shosetsu.android.view.compose
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.dp
+
+fun Modifier.selectedOutline(isSelected: Boolean) = composed {
+    val secondary = MaterialTheme.colors.secondary
+    if (isSelected) {
+        drawBehind {
+            val additional = 24.dp.value
+            val offset = additional / 2
+            val height = size.height + additional
+            val width = size.width + additional
+            drawRoundRect(
+                color = secondary,
+                topLeft = Offset(-offset, -offset),
+                size = Size(width, height),
+                cornerRadius = CornerRadius(offset),
+            )
+        }
+    } else {
+        this
+    }
+}

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/ButtonSettingContent.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/ButtonSettingContent.kt
@@ -42,7 +42,7 @@ fun ButtonSettingContent(
 	modifier: Modifier = Modifier,
 	onClick: () -> Unit
 ) {
-	GenericRightSettingLayout(title, description, modifier) {
+	GenericRightSettingLayout(title, description, modifier, onClick = onClick) {
 		Button(
 			onClick
 		) {

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/DropdownSettingContent.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/DropdownSettingContent.kt
@@ -3,8 +3,17 @@ package app.shosetsu.android.view.compose.setting
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.IconToggleButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -62,7 +71,7 @@ fun DropdownSettingContent(
 ) {
 	var expanded by remember { mutableStateOf(false) }
 
-	GenericRightSettingLayout(title, description, modifier) {
+	GenericRightSettingLayout(title, description, modifier, onClick = { expanded = !expanded }) {
 		Row(
 			verticalAlignment = Alignment.CenterVertically,
 		) {

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/GenericBottomSettingLayout.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/GenericBottomSettingLayout.kt
@@ -1,12 +1,15 @@
 package app.shosetsu.android.view.compose.setting
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.shosetsu.android.view.compose.ShosetsuCompose
 import com.github.doomsdayrs.apps.shosetsu.R
@@ -32,7 +35,9 @@ fun GenericBottomSettingLayout(
 	bottom: @Composable () -> Unit
 ) {
 	Column(
-		modifier = modifier,
+		modifier = modifier then Modifier
+			.defaultMinSize(minHeight = 56.dp)
+			.padding(horizontal = 16.dp),
 	) {
 		Column {
 			Text(title)

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/GenericRightSettingLayout.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/GenericRightSettingLayout.kt
@@ -1,15 +1,19 @@
 package app.shosetsu.android.view.compose.setting
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.shosetsu.android.view.compose.ShosetsuCompose
 import com.github.doomsdayrs.apps.shosetsu.R
@@ -32,10 +36,18 @@ fun GenericRightSettingLayout(
 	title: String,
 	description: String,
 	modifier: Modifier = Modifier,
+	onClick: (() -> Unit)? = null,
 	right: @Composable () -> Unit
 ) {
 	Row(
-		modifier = modifier,
+		modifier = modifier then Modifier
+			.defaultMinSize(minHeight = 56.dp)
+			.let {
+				if (onClick != null)
+					it.clickable(onClick = onClick)
+				else it
+			}
+			.padding(horizontal = 16.dp),
 		verticalAlignment = Alignment.CenterVertically,
 		horizontalArrangement = Arrangement.SpaceBetween
 	) {

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/HeaderSettingContent.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/HeaderSettingContent.kt
@@ -47,7 +47,7 @@ fun HeaderSettingContent(
 	name: String,
 	modifier: Modifier = Modifier
 ) {
-	Column(modifier = modifier) {
+	Column(modifier = modifier then Modifier.padding(horizontal = 16.dp)) {
 		Text(
 			name,
 			style = MaterialTheme.typography.h6,

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/NumberPickerSettingContent.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/NumberPickerSettingContent.kt
@@ -1,11 +1,20 @@
 package app.shosetsu.android.view.compose.setting
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Card
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -46,7 +55,7 @@ fun NumberPickerSettingContent(
 ) {
 	var openDialog by remember { mutableStateOf(false) }
 
-	GenericRightSettingLayout(title, description, modifier) {
+	GenericRightSettingLayout(title, description, modifier, onClick = { openDialog = !openDialog }) {
 		IconButton({
 			openDialog = true
 		}) {

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/StringReaderSettingContent.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/StringReaderSettingContent.kt
@@ -2,6 +2,7 @@ package app.shosetsu.android.view.compose.setting
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
@@ -40,7 +41,7 @@ fun StringSettingContent(
 	Column(
 		modifier = modifier,
 	) {
-		TextField(
+		OutlinedTextField(
 			value = value,
 			onValueChange = onValueChanged,
 			label = { Text(title) },

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/SwitchSettingContent.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/SwitchSettingContent.kt
@@ -24,10 +24,10 @@ fun SwitchSettingContent(
 	modifier: Modifier = Modifier,
 	onCheckChange: (newValue: Boolean) -> Unit
 ) {
-	GenericRightSettingLayout(title, description, modifier) {
+	GenericRightSettingLayout(title, description, modifier, onClick = { onCheckChange(!isChecked) }) {
 		Switch(
 			isChecked,
-			onCheckChange,
+			null,
 		)
 	}
 }

--- a/android/src/main/java/app/shosetsu/android/view/uimodels/model/BrowseExtensionUI.kt
+++ b/android/src/main/java/app/shosetsu/android/view/uimodels/model/BrowseExtensionUI.kt
@@ -1,0 +1,41 @@
+package app.shosetsu.android.view.uimodels.model
+
+import androidx.compose.runtime.Immutable
+import app.shosetsu.android.domain.model.local.ExtensionInstallOptionEntity
+import app.shosetsu.lib.Version
+import java.util.Locale
+
+/*
+ * This file is part of shosetsu.
+ *
+ * shosetsu is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * shosetsu is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with shosetsu.  If not, see <https://www.gnu.org/licenses/>.
+ * ====================================================================
+ */
+
+@Immutable
+data class BrowseExtensionUI(
+    val id: Int,
+    val name: String,
+    val imageURL: String,
+    val lang: String,
+    val installOptions: List<ExtensionInstallOptionEntity>? = null,
+    val isInstalled: Boolean,
+    val installedVersion: Version? = null,
+    val installedRepo: Int,
+    val isUpdateAvailable: Boolean,
+    val updateVersion: Version? = null,
+    val isInstalling: Boolean
+) {
+    val displayLang: String = Locale.forLanguageTag(lang).displayName
+}

--- a/android/src/main/java/app/shosetsu/android/view/uimodels/model/InstalledExtensionUI.kt
+++ b/android/src/main/java/app/shosetsu/android/view/uimodels/model/InstalledExtensionUI.kt
@@ -1,0 +1,58 @@
+package app.shosetsu.android.view.uimodels.model
+
+import androidx.compose.runtime.Immutable
+import app.shosetsu.android.domain.model.local.InstalledExtensionEntity
+import app.shosetsu.android.dto.Convertible
+import app.shosetsu.lib.ExtensionType
+import app.shosetsu.lib.Novel
+import app.shosetsu.lib.Version
+import java.util.Locale
+
+/*
+ * This file is part of shosetsu.
+ *
+ * shosetsu is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * shosetsu is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with shosetsu.  If not, see <https://www.gnu.org/licenses/>.
+ * ====================================================================
+ */
+
+@Immutable
+data class InstalledExtensionUI(
+    val id: Int,
+    val repoID: Int,
+    val name: String,
+    val fileName: String,
+    val imageURL: String,
+    val lang: String,
+    val version: Version,
+    val md5: String,
+    val type: ExtensionType,
+    val enabled: Boolean,
+    val chapterType: Novel.ChapterType,
+) : Convertible<InstalledExtensionEntity> {
+    val displayLang: String = Locale.forLanguageTag(lang).displayName
+
+    override fun convertTo(): InstalledExtensionEntity  = InstalledExtensionEntity(
+        id = id,
+        repoID = repoID,
+        name = name,
+        fileName = fileName,
+        imageURL = imageURL,
+        lang = lang,
+        version = version,
+        md5 = md5,
+        type = type,
+        enabled = enabled,
+        chapterType = chapterType,
+    )
+}

--- a/android/src/main/java/app/shosetsu/android/viewmodel/abstracted/ABrowseViewModel.kt
+++ b/android/src/main/java/app/shosetsu/android/viewmodel/abstracted/ABrowseViewModel.kt
@@ -1,12 +1,13 @@
 package app.shosetsu.android.viewmodel.abstracted
 
 import androidx.compose.runtime.Immutable
-import app.shosetsu.android.domain.model.local.BrowseExtensionEntity
 import app.shosetsu.android.domain.model.local.ExtensionInstallOptionEntity
+import app.shosetsu.android.view.uimodels.model.BrowseExtensionUI
 import app.shosetsu.android.viewmodel.base.IsOnlineCheckViewModel
 import app.shosetsu.android.viewmodel.base.ShosetsuViewModel
 import app.shosetsu.android.viewmodel.base.SubscribeViewModel
 import kotlinx.coroutines.flow.Flow
+import java.util.Locale
 
 /*
  * This file is part of shosetsu.
@@ -34,12 +35,17 @@ import kotlinx.coroutines.flow.Flow
  */
 abstract class ABrowseViewModel :
 	ShosetsuViewModel(),
-	SubscribeViewModel<List<BrowseExtensionEntity>>,
+	SubscribeViewModel<List<BrowseExtensionUI>>,
 	IsOnlineCheckViewModel {
 
 	@Immutable
+	data class LanguageFilter(val lang: String, val displayLang: String) {
+		constructor(lang: String) : this(lang, Locale.forLanguageTag(lang).displayName)
+	}
+
+	@Immutable
 	data class FilteredLanguages(
-		val languages: List<String>,
+		val languages: List<LanguageFilter>,
 		val states: Map<String, Boolean>
 	)
 
@@ -48,15 +54,15 @@ abstract class ABrowseViewModel :
 
 	/** Installs an extension */
 	abstract fun installExtension(
-		extension: BrowseExtensionEntity,
+		extension: BrowseExtensionUI,
 		option: ExtensionInstallOptionEntity
 	)
 
 	/** Update an extension, only works if it is already installed */
-	abstract fun updateExtension(ext: BrowseExtensionEntity)
+	abstract fun updateExtension(ext: BrowseExtensionUI)
 
 	/** Cancel an extension install */
-	abstract fun cancelInstall(ext: BrowseExtensionEntity)
+	abstract fun cancelInstall(ext: BrowseExtensionUI)
 
 
 	/**

--- a/android/src/main/java/app/shosetsu/android/viewmodel/abstracted/AExtensionConfigureViewModel.kt
+++ b/android/src/main/java/app/shosetsu/android/viewmodel/abstracted/AExtensionConfigureViewModel.kt
@@ -2,7 +2,7 @@ package app.shosetsu.android.viewmodel.abstracted
 
 import androidx.compose.runtime.Immutable
 import app.shosetsu.android.domain.model.local.FilterEntity
-import app.shosetsu.android.domain.model.local.InstalledExtensionEntity
+import app.shosetsu.android.view.uimodels.model.InstalledExtensionUI
 import app.shosetsu.android.viewmodel.base.ShosetsuViewModel
 import app.shosetsu.android.viewmodel.base.SubscribeViewModel
 import kotlinx.coroutines.flow.Flow
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.Flow
  * [liveData] is of the formatter object itself
  */
 abstract class AExtensionConfigureViewModel
-	: ShosetsuViewModel(), SubscribeViewModel<InstalledExtensionEntity?> {
+	: ShosetsuViewModel(), SubscribeViewModel<InstalledExtensionUI?> {
 
 	abstract val extensionListing: Flow<ListingSelectionData>
 	abstract val extensionSettings: Flow<List<FilterEntity>>
@@ -51,7 +51,7 @@ abstract class AExtensionConfigureViewModel
 	/**
 	 * Uninstall this extension
 	 */
-	abstract fun uninstall(extension: InstalledExtensionEntity)
+	abstract fun uninstall(extension: InstalledExtensionUI)
 
 	/**
 	 * Destroy this controller

--- a/android/src/main/java/app/shosetsu/android/viewmodel/abstracted/ALibraryViewModel.kt
+++ b/android/src/main/java/app/shosetsu/android/viewmodel/abstracted/ALibraryViewModel.kt
@@ -60,6 +60,7 @@ abstract class ALibraryViewModel :
 
 	abstract val columnsInH: Flow<Int>
 	abstract val columnsInV: Flow<Int>
+	abstract val badgeUnreadToastFlow: Flow<Boolean>
 
 	abstract fun cycleUnreadFilter(currentState: ToggleableState)
 	abstract fun getUnreadFilter(): Flow<ToggleableState>

--- a/android/src/main/java/app/shosetsu/android/viewmodel/impl/LibraryViewModel.kt
+++ b/android/src/main/java/app/shosetsu/android/viewmodel/impl/LibraryViewModel.kt
@@ -28,6 +28,7 @@ import app.shosetsu.android.common.ext.logE
 import app.shosetsu.android.common.utils.copy
 import app.shosetsu.android.domain.usecases.IsOnlineUseCase
 import app.shosetsu.android.domain.usecases.load.LoadLibraryUseCase
+import app.shosetsu.android.domain.usecases.load.LoadNovelUIBadgeToastUseCase
 import app.shosetsu.android.domain.usecases.load.LoadNovelUIColumnsHUseCase
 import app.shosetsu.android.domain.usecases.load.LoadNovelUIColumnsPUseCase
 import app.shosetsu.android.domain.usecases.load.LoadNovelUITypeUseCase
@@ -56,6 +57,7 @@ class LibraryViewModel(
 	private val loadNovelUITypeUseCase: LoadNovelUITypeUseCase,
 	private val loadNovelUIColumnsH: LoadNovelUIColumnsHUseCase,
 	private val loadNovelUIColumnsP: LoadNovelUIColumnsPUseCase,
+	private val loadNovelUIBadgeToast: LoadNovelUIBadgeToastUseCase,
 	private val setNovelUITypeUseCase: SetNovelUITypeUseCase
 ) : ALibraryViewModel() {
 
@@ -230,6 +232,10 @@ class LibraryViewModel(
 
 	override val columnsInV by lazy {
 		loadNovelUIColumnsP().onIO()
+	}
+
+	override val badgeUnreadToastFlow by lazy {
+		loadNovelUIBadgeToast().onIO()
 	}
 
 	/**

--- a/android/src/main/java/app/shosetsu/android/viewmodel/impl/extension/ExtensionConfigureViewModel.kt
+++ b/android/src/main/java/app/shosetsu/android/viewmodel/impl/extension/ExtensionConfigureViewModel.kt
@@ -21,7 +21,6 @@ import app.shosetsu.android.common.ext.launchIO
 import app.shosetsu.android.common.ext.logI
 import app.shosetsu.android.common.ext.logV
 import app.shosetsu.android.domain.model.local.FilterEntity
-import app.shosetsu.android.domain.model.local.InstalledExtensionEntity
 import app.shosetsu.android.domain.usecases.UninstallExtensionUseCase
 import app.shosetsu.android.domain.usecases.get.GetExtListingNamesUseCase
 import app.shosetsu.android.domain.usecases.get.GetExtSelectedListingFlowUseCase
@@ -29,6 +28,7 @@ import app.shosetsu.android.domain.usecases.get.GetExtensionSettingsUseCase
 import app.shosetsu.android.domain.usecases.get.GetInstalledExtensionUseCase
 import app.shosetsu.android.domain.usecases.update.UpdateExtSelectedListing
 import app.shosetsu.android.domain.usecases.update.UpdateExtensionSettingUseCase
+import app.shosetsu.android.view.uimodels.model.InstalledExtensionUI
 import app.shosetsu.android.viewmodel.abstracted.AExtensionConfigureViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
@@ -51,7 +51,7 @@ class ExtensionConfigureViewModel(
 ) : AExtensionConfigureViewModel() {
 	private val extensionIdFlow: MutableStateFlow<Int> by lazy { MutableStateFlow(-1) }
 
-	override val liveData: Flow<InstalledExtensionEntity?> by lazy {
+	override val liveData: Flow<InstalledExtensionUI?> by lazy {
 		extensionIdFlow.transformLatest { id ->
 			emitAll(loadInstalledExtension(id))
 		}.onIO()
@@ -103,7 +103,7 @@ class ExtensionConfigureViewModel(
 		}
 	}
 
-	override fun uninstall(extension: InstalledExtensionEntity) {
+	override fun uninstall(extension: InstalledExtensionUI) {
 		launchIO {
 			uninstallExtensionUI(extension)
 		}

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -259,6 +259,8 @@
     <string name="comfy">Comfy</string>
     <string name="novel_card_type_selector_title">Novel card type</string>
     <string name="novel_card_type_selector_desc">Swap between a grid or list for displaying novels</string>
+    <string name="novel_badge_toast_title">Novel badge toast</string>
+    <string name="novel_badge_toast_desc">Toast when the unread badge is clicked to explain what it is for</string>
     <string name="library_update">Updating Library</string>
     <string name="catalogue_default_load">Default home page</string>
     <string name="catalogue_default_load_desc">When a catalogue is selected, This is the thing it loads</string>


### PR DESCRIPTION
Finished a bunch of UI tweaks. Main highlights are
- Padding for click indicators look much better by applying padding after the clickable. This is done by removing padding from parent composables and applying it to the children instead.
- Add animations where possible, like expanding filter menu groups or switching between tabs
- Images now all crossfade between states
- Better image loading error display
- Consistent image loading placeholder
- Add display for languages instead of just showing the language code
- The linear loading indicator now overlays instead of being added between the toolbar and the content
- Use OutlinedTextFields instead of basic TextFields since they look better
- Handle no more content in catelog properly so its not displayed before loading
- Add BackHandler for library selection so it doesnt close the app when trying to deselect
- Replace clickable unread chip with a badge thats not clickable since it doesnt make sense to click it
- Selection background instead of a border for library and chapter list
- Clicking a settings item now starts/toggles/expands that setting
- Clicking a filter item now toggles/expands that filter
- Use a better cover ratio


### Comparisons
#### Ignore the theme colors these were taken on different devices
| Old | New |
| ------- | ------- |
|![Screenshot_20220806_170509](https://user-images.githubusercontent.com/17078382/183315246-29951f13-92eb-41e1-834a-08e269cff1fe.png)|![Screenshot_20220806_170535](https://user-images.githubusercontent.com/17078382/183315257-1921fbba-61f5-4437-88ac-fb471481f0de.png)|
|![Screenshot_20220806_170436](https://user-images.githubusercontent.com/17078382/183315276-18613a8f-6600-419f-8b5a-76e5033e05d6.png)|![Screenshot_20220806_170415](https://user-images.githubusercontent.com/17078382/183315278-9a147533-7f44-4a8b-8c46-50ce99290578.png)|
|![Screenshot_20220806_171718](https://user-images.githubusercontent.com/17078382/183315386-d6894ae6-77e8-46ae-9057-292fe387814c.png)|![Screenshot_20220806_171800](https://user-images.githubusercontent.com/17078382/183315388-2e16dc0b-c74b-4010-b1e3-518611458e0a.png)|
|![Screenshot_20220807_191340](https://user-images.githubusercontent.com/17078382/183315411-48b377ce-68b2-44d2-89b6-8b5aa3a807cf.png)|![Screenshot_20220807_191306](https://user-images.githubusercontent.com/17078382/183315410-b38c61e5-c96f-4a33-bba8-1c1b69804723.png)|
|![Screenshot_20220806_171529](https://user-images.githubusercontent.com/17078382/183315450-0be37807-2f2f-44d7-8fb6-03d8570324d4.png)|![Screenshot_20220806_171641](https://user-images.githubusercontent.com/17078382/183315449-3e79e5cb-5f54-4897-a1be-bfe96d1c7d41.png)|
![Screenshot_20220806_171157](https://user-images.githubusercontent.com/17078382/183315476-4527a8fd-81e9-4b0d-a624-663b5a046931.png)|![Screenshot_20220806_171045](https://user-images.githubusercontent.com/17078382/183315473-ef0b0063-c10b-454d-9765-90ab2a11a599.png)|
|![Screenshot_20220806_172137](https://user-images.githubusercontent.com/17078382/183315506-1b51aa92-a9be-46f9-ad05-cad61d82a903.png)|![Screenshot_20220806_172110](https://user-images.githubusercontent.com/17078382/183315504-3b21adf9-bef3-420e-8e7f-8b6d8ed7263b.png)|
|![Screenshot_20220806_171233](https://user-images.githubusercontent.com/17078382/183315556-ec7996ac-ef44-4af3-9620-f6b2bd39f52f.png)|![Screenshot_20220806_171314](https://user-images.githubusercontent.com/17078382/183315559-2b246b7e-a851-4a58-acb0-e947165fe0d5.png)|
|![Screenshot_20220806_171402](https://user-images.githubusercontent.com/17078382/183315581-e6ff19ff-f5d5-48f6-b7a9-09da027e0c67.png)|![Screenshot_20220806_171432](https://user-images.githubusercontent.com/17078382/183315590-b4675807-5e48-4b96-a26a-ff8f5d0ddb20.png)|






